### PR TITLE
feat: read Gemini key from env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ WORKDIR /app
 COPY ./ /app/
 RUN pip install --no-cache-dir -r requirements.txt
 ENV TELEGRAM_BOT_API_KEY=""
-ENV GEMINI_API_KEYS=""
-CMD ["sh", "-c", "python main.py ${TELEGRAM_BOT_API_KEY} ${GEMINI_API_KEYS}"]
+ENV GOOGLE_GEMINI_KEY=""
+CMD ["sh", "-c", "python main.py ${TELEGRAM_BOT_API_KEY}"]

--- a/README.md
+++ b/README.md
@@ -11,14 +11,18 @@ pip install -r requirements.txt
 ```
 2. 在[BotFather](https://t.me/BotFather)获取Telegram Bot API
 3. 在[Google AI Studio](https://makersuite.google.com/app/apikey)获取Gemini API keys
-4. 运行机器人，执行以下命令：
+4. 设置环境变量
 ```
-python main.py ${Telegram 机器人 API} ${Gemini API 密钥}
+export GOOGLE_GEMINI_KEY="${Gemini API 密钥}"
+```
+5. 运行机器人，执行以下命令：
+```
+python main.py ${Telegram 机器人 API}
 ```
 ## (2)使用 Docker 部署
 ### 使用构建好的镜像(x86 only)
 ```
-docker run -d --restart=always -e TELEGRAM_BOT_API_KEY={Telegram 机器人 API} -e GEMINI_API_KEYS={Gemini API 密钥} qwqhthqwq/gemini-telegram-bot:main
+docker run -d --restart=always -e TELEGRAM_BOT_API_KEY={Telegram 机器人 API} -e GOOGLE_GEMINI_KEY={Gemini API 密钥} qwqhthqwq/gemini-telegram-bot:main
 ```
 ### 自行构建
 1. 在[BotFather](https://t.me/BotFather)获取Telegram Bot API
@@ -37,7 +41,7 @@ docker build -t gemini_tg_bot .
 ```
 6. 运行镜像
 ```
-docker run -d --restart=always -e TELEGRAM_BOT_API_KEY={Telegram 机器人 API} -e GEMINI_API_KEYS={Gemini API 密钥} gemini_tg_bot
+docker run -d --restart=always -e TELEGRAM_BOT_API_KEY={Telegram 机器人 API} -e GOOGLE_GEMINI_KEY={Gemini API 密钥} gemini_tg_bot
 ```
 
 ## (3)使用 Railway 部署

--- a/README_en.md
+++ b/README_en.md
@@ -11,14 +11,18 @@ pip install -r requirements.txt
 ```
 2. Obtain Telegram Bot API at [BotFather](https://t.me/BotFather)
 3. Get Gemini API keys from [Google AI Studio](https://makersuite.google.com/app/apikey)
-4. To run the bot, execute:
+4. Set environment variable
 ```
-python main.py ${Telegram Bot API} ${Gemini API keys}
+export GOOGLE_GEMINI_KEY="${Gemini API keys}"
+```
+5. To run the bot, execute:
+```
+python main.py ${Telegram Bot API}
 ```
 ## (2)Deploy Using Docker
 ### Use the built image(x86 only)
 ```
-docker run -d --restart=always -e TELEGRAM_BOT_API_KEY={Telegram Bot API} -e GEMINI_API_KEYS={Gemini API Key} qwqhthqwq/gemini-telegram-bot:main
+docker run -d --restart=always -e TELEGRAM_BOT_API_KEY={Telegram Bot API} -e GOOGLE_GEMINI_KEY={Gemini API Key} qwqhthqwq/gemini-telegram-bot:main
 ```
 ### build by yourself
 1. Get Telegram Bot API at [BotFather](https://t.me/BotFather)
@@ -37,7 +41,7 @@ docker build -t gemini_tg_bot .
 ```
 6. run
 ```
-docker run -d --restart=always -e TELEGRAM_BOT_API_KEY={Telegram Bot API} -e GEMINI_API_KEYS={Gemini API Key} gemini_tg_bot
+docker run -d --restart=always -e TELEGRAM_BOT_API_KEY={Telegram Bot API} -e GOOGLE_GEMINI_KEY={Gemini API Key} gemini_tg_bot
 ```
 
 ## (3)Deploy on Railway

--- a/gemini.py
+++ b/gemini.py
@@ -1,7 +1,7 @@
 import io
 import time
 import traceback
-import sys
+import os
 from PIL import Image
 from telebot.types import Message
 from md2tgmd import escape
@@ -23,7 +23,7 @@ download_pic_notify     =       conf["download_pic_notify"]
 
 search_tool = {'google_search': {}}
 
-client = genai.Client(api_key=sys.argv[2])
+client = genai.Client(api_key=os.getenv("GOOGLE_GEMINI_KEY"))
 
 async def gemini_stream(bot:TeleBot, message:Message, m:str, model_type:str):
     sent_message = None

--- a/main.py
+++ b/main.py
@@ -10,7 +10,6 @@ from config import conf, generation_config, safety_settings
 # Init args
 parser = argparse.ArgumentParser()
 parser.add_argument("tg_token", help="токен Telegram")
-parser.add_argument("GOOGLE_GEMINI_KEY", help="API‑ключ Google Gemini")
 options = parser.parse_args()
 print("Аргументы обработаны.")
 


### PR DESCRIPTION
## Summary
- read Gemini API key from `GOOGLE_GEMINI_KEY` environment variable
- drop CLI argument for Gemini key
- document environment variable setup in README and Docker

## Testing
- `python -m py_compile gemini.py main.py handlers.py config.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9c52b8f90832586c34b7d6a66c059