### PR TITLE
Fix exception string conversion

### DIFF
--- a/gemini.py
+++ b/gemini.py
@@ -114,7 +114,7 @@ async def gemini_edit(bot: TeleBot, message: Message, m: str, photo_file: bytes)
         config=generation_config
     )
     except Exception as e:
-        await bot.send_message(message.chat.id, e.str())
+        await bot.send_message(message.chat.id, str(e))
     for part in response.candidates[0].content.parts:
         if part.text is not None:
             await bot.send_message(message.chat.id, escape(part.text), parse_mode="MarkdownV2")

--- a/handlers.py
+++ b/handlers.py
@@ -124,7 +124,7 @@ async def gemini_edit_handler(message: Message, bot: TeleBot) -> None:
         photo_file = await bot.download_file(file_path.file_path)
     except Exception as e:
         traceback.print_exc()
-        await bot.reply_to(message, e.str())
+        await bot.reply_to(message, str(e))
         return
     await gemini.gemini_edit(bot, message, m, photo_file)
 


### PR DESCRIPTION
## Summary
- Replace deprecated `e.str()` calls with `str(e)` in Gemini error handling
- Ensure all exception handlers use `str(e)` for error messages

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b9c52d2b58832589cad0bebab99cab