### PR TITLE
Improve logging for Gemini Telegram Bot

### DIFF
--- a/gemini.py
+++ b/gemini.py
@@ -1,6 +1,6 @@
 import io
 import time
-import traceback
+import logging
 import sys
 from PIL import Image
 from telebot.types import Message
@@ -8,6 +8,8 @@ from md2tgmd import escape
 from telebot import TeleBot
 from config import conf, generation_config
 from google import genai
+
+logging.basicConfig(level=logging.INFO)
 
 gemini_draw_dict = {}
 gemini_chat_dict = {}
@@ -71,7 +73,7 @@ async def gemini_stream(bot:TeleBot, message:Message, m:str, model_type:str):
                                 )
                         else:
                             if "message is not modified" not in str(e).lower():
-                                print(f"Ошибка обновления сообщения: {e}")
+                                logging.warning(f"Ошибка обновления сообщения: {e}")
                     last_update = current_time
 
         try:
@@ -90,11 +92,11 @@ async def gemini_stream(bot:TeleBot, message:Message, m:str, model_type:str):
                         message_id=sent_message.message_id
                     )
             except Exception:
-                traceback.print_exc()
+                logging.exception("Не удалось обновить сообщение после обработки Markdown")
 
 
     except Exception as e:
-        traceback.print_exc()
+        logging.exception("Ошибка в gemini_stream")
         if sent_message:
             await bot.edit_message_text(
                 f"{error_info}\nПодробности ошибки: {str(e)}",

--- a/handlers.py
+++ b/handlers.py
@@ -1,9 +1,11 @@
 from telebot import TeleBot
 from telebot.types import Message
 from md2tgmd import escape
-import traceback
+import logging
 from config import conf
 import gemini
+
+logging.basicConfig(level=logging.INFO)
 
 error_info              =       conf["error_info"]
 before_generate_info    =       conf["before_generate_info"]
@@ -97,7 +99,7 @@ async def gemini_photo_handler(message: Message, bot: TeleBot) -> None:
             file_path = await bot.get_file(message.photo[-1].file_id)
             photo_file = await bot.download_file(file_path.file_path)
         except Exception:
-            traceback.print_exc()
+            logging.exception("Ошибка при обработке фото в группе")
             await bot.reply_to(message, error_info)
             return
         await gemini.gemini_edit(bot, message, m, photo_file)
@@ -108,7 +110,7 @@ async def gemini_photo_handler(message: Message, bot: TeleBot) -> None:
             file_path = await bot.get_file(message.photo[-1].file_id)
             photo_file = await bot.download_file(file_path.file_path)
         except Exception:
-            traceback.print_exc()
+            logging.exception("Ошибка при обработке фото в личном чате")
             await bot.reply_to(message, error_info)
             return
         await gemini.gemini_edit(bot, message, m, photo_file)
@@ -123,7 +125,7 @@ async def gemini_edit_handler(message: Message, bot: TeleBot) -> None:
         file_path = await bot.get_file(message.photo[-1].file_id)
         photo_file = await bot.download_file(file_path.file_path)
     except Exception as e:
-        traceback.print_exc()
+        logging.exception("Ошибка при редактировании изображения")
         await bot.reply_to(message, e.str())
         return
     await gemini.gemini_edit(bot, message, m, photo_file)


### PR DESCRIPTION
## Summary
- configure logging and replace print/traceback usage in gemini.py
- configure logging and replace traceback usage in handlers.py

## Testing
- `python -m py_compile gemini.py handlers.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9c539db4c83259d05c0134c56a3b5